### PR TITLE
Bump sicmutils, fix linter warnings

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -12,8 +12,8 @@
         ;; some statistical routines
         kixi/stats {:mvn/version "0.5.4"}
 
-        ;; SICM utils numerical and physics routines
-        sicmutils/sicmutils {:mvn/version "0.20.1"}
+        ;; SICMUtils numerical and physics routines
+        sicmutils/sicmutils {:mvn/version "0.22.0"}
 
         ;; semantic web goodies and box/arrow graphs
         jackrusher/mundaneum               {:git/url "https://github.com/jackrusher/mundaneum/"


### PR DESCRIPTION
This namespace exposed a bug in my linter hooks that I'll need to fix!

This latest version runs the simulations much faster, so notebook compilation and rebuild should be fast now (350ms vs 2300 ms on my machine for each run).