### PR TITLE
Add nREPL dependency and usage docs for newbies

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,39 @@
 # Clerk Examples and Demos
 
 This is a preview of Clerk before its open source release. See the
-[Clerk README](https://nextjournal.com/mk/clerk-preview) for more information.
+[Clerk README](https://nextjournal.com/mk/clerk-preview) for more information
+and for starting your own project.
 
-To play with this, eval forms in [dev/user.clj](dev/user.clj).
+## Running these demo notebooks
+To appreciate the full power of Clerk we *strongly* recommend you spend the time to [configure your editor](https://clojure.org/guides/editors) to evaluate forms inline, but Clerk does not require it. Instructions for each below.
+
+### Using a standalone Clojure REPL
+After cloning this repo & setting this directory as the cwd:
+
+```
+clj
+```
+
+This will open a REPL that will look something like:
+```
+Clojure 1.11.1
+user=>
+```
+
+Open [dev/user.clj](dev/user.clj) and copy/paste one of the `(clerk/serve!)` forms to start the server, then one of the `(clerk/show!)` forms to choose which notebook to display.
+
+Go to http://localhost:7777/ ::tada::
+
+
+### Using an Editor-connected nREPL
+After cloning this repo & setting this directory as the cwd:
+
+```
+clj -M:nREPL -m nrepl.cmdline
+```
+
+Then simply connect your editor to the host & port indicated after the "nREPL server started on port" log trace.
+
+Open [dev/user.clj](dev/user.clj) and evaluate the commented forms depending on which paths you would like to serve and which demo notebooks you would like to see.
+
+Go to http://localhost:7777/ ::tada::

--- a/deps.edn
+++ b/deps.edn
@@ -41,4 +41,7 @@
                        "notebooks/semantic.clj"
                        "notebooks/sicmutils.clj"
                        "notebooks/rule_30.clj"
-                       "notebooks/zipper_with_scars.clj"]}}}}
+                       "notebooks/zipper_with_scars.clj"]}}
+  :nREPL
+  {:extra-deps
+   {nrepl/nrepl {:mvn/version "0.9.0"}}}}}


### PR DESCRIPTION
Afternoon folks!

I finally got around to playing with Clerk since watching your amazing demos. I was hoping to start by firing up these demo notebooks and editing them, but I ran into several issues with the initial setup. It's *very* likely these are just because I am a total n00b and these solutions are obvious to someone with a bit more experience, but I thought I'd write up some instructions just in case.

I know you all are actively working on this stuff so I won't be at all offended if you immediately close this PR as WAD, can see several ways this might not be sth you'd want to support.

## The problem
AFAICT there is no way to launch an nREPL from within this repo without adding the included line to the `deps.edn` because:
- `lein nrepl` followed by evaluating the forms fails with `Could not locate nextjournal/clerk__init.class` because no dependencies are installed (& still fails once you run `clj` to install them AFAICT.)
    - `lein deps` fails because there's no `project.clj`
- I couldn't find an easy way to launch an nREPL/socket server accessing these with plain Clojure

## A solution
The attached PR which--
- Adds the included nREPL middleware to deps.edn
- Adds reference usage instructions for running with both nREPL and plain `clj` 