### PR TITLE
fixed suggested github workflow

### DIFF
--- a/notebooks/static_site_generation.md
+++ b/notebooks/static_site_generation.md
@@ -12,50 +12,83 @@ To publish a collection of clerk notebooks to github pages (like this guide) we 
 and a e.g. `.github/workflows/main.yml` to your repo with the following steps:
 
 
-    name Publish to Pages
-    on: push
-    jobs:
-      static-build:
-      runs-on: ubuntu-latest
-      steps:
-        - name: 🛎️ Checkout
-          uses: actions/checkout@v2
+        name: Deploy to GitHub Pages
+        
+        on:
+          push:
+            #branches: [master] #uncomment this to only respond to a push to master
+        
+          # Allows you to run this workflow manually from the Actions tab
+          workflow_dispatch:
+        
+        # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+        permissions:
+          contents: read
+          pages: write
+          id-token: write
+        
+        # Allow one concurrent deployment
+        concurrency:
+          group: "pages"
+          cancel-in-progress: true
+        
+        jobs:
+          # Build job
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Checkout
+                uses: actions/checkout@v3
+              - name: Setup Pages
+                uses: actions/configure-pages@v1
+        
+              - name: 🔧 Install java
+                uses: actions/setup-java@v1
+                with:
+                  java-version: '11.0.7'
+        
+              - name: 🔧 Install clojure
+                uses: DeLaGuardo/setup-clojure@master
+                with:
+                  cli: '1.10.3.943'
+        
+              - name: 🗝 maven cache
+                uses: actions/cache@v2
+                with:
+                  path: |
+                    ~/.m2
+                    ~/.gitlibs
+                  key: ${{ runner.os }}-maven-${{ github.sha }}
+                  restore-keys: |
+                    ${{ runner.os }}-maven-
+        
+              - name: 🗝 Clerk Cache
+                uses: actions/cache@v2
+                with:
+                  path: .cache
+                  key: ${{ runner.os }}-clerk
+        
+              - name: 🏗 Clerk Build
+                run: clojure -X:nextjournal/clerk :path-prefix '"jointprob-clerk/"' :git/sha '"${{ github.sha }}"'
+        
+              - name: Upload artifact
+                uses: actions/upload-pages-artifact@v1
+                with:
+                  # Upload entire repository
+                  path: 'public/build'
+        
+          # Deployment job
+          deploy:
+            environment:
+              name: github-pages
+              url: ${{ steps.deployment.outputs.page_url }}
+            runs-on: ubuntu-latest
+            needs: build
+            steps:
+              - name: Deploy to GitHub Pages
+                id: deployment
+                uses: actions/deploy-pages@v1
 
-        - name: 🔧 Install java
-          uses: actions/setup-java@v1
-          with:
-            java-version: '11.0.7'
-    
-        - name: 🔧 Install clojure
-          uses: DeLaGuardo/setup-clojure@master
-          with:
-            cli: '1.10.3.943'
-    
-        - name: 🗝 maven cache
-          uses: actions/cache@v2
-          with:
-            path: |
-              ~/.m2
-              ~/.gitlibs
-            key: ${{ runner.os }}-maven-${{ github.sha }}
-            restore-keys: |
-              ${{ runner.os }}-maven-
-    
-        - name: 🗝 Clerk Cache
-            uses: actions/cache@v2
-            with:
-              path: .cache
-              key: ${{ runner.os }}-clerk
-    
-        - name: 🏗 Clerk Build
-          run: clojure -X:nextjournal/clerk
-    
-        - name: 🚀 Deploy
-          uses: JamesIves/github-pages-deploy-action@4.1.6
-          with:
-            branch: gh-pages
-            folder: public/build
-    
     
 You might want to add this badge in your repo's readme :-)
 


### PR DESCRIPTION
Your suggested github workflow didn't work for me.

I'm not totally sure I wasn't doing something wrong but I couldn't get the actual content served at github.io to update although the workflow did update the gh-pages branch.

I changed to this workflow and the workflow now actually serves the files from gh-pages after committing them to the gh-pages branch.