### PR TITLE
Migrate sicmutils => emmy, add bug repros

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["dev" "notebooks" "resources"]
- :deps {io.github.nextjournal/clerk {:git/sha "fa0ddcf000bbcd211008c93d8bd0b3047629f6b6"}
+ :deps {io.github.nextjournal/clerk {:git/sha "9fa6b3761fec5544bacdf4117d0ec9b87b411a40"}
         io.github.nextjournal/clerk-slideshow {:git/sha "ea9b27e5ec2e5ad57e889060521451ed9138325b"}
 
         ;; keep 1.10 until `kixi/stats` and `sicmutils` fix warnings
@@ -16,8 +16,8 @@
         ;; some statistical routines
         kixi/stats {:mvn/version "0.5.4"}
 
-        ;; SICMUtils numerical and physics routines
-        sicmutils/sicmutils {:mvn/version "0.22.0"}
+        ;; Emmy numerical and physics routines
+        io.github.mentat-collective/emmy {:git/sha "b98fef51d80d3edcff3100562b929f9980ff34d7"}
 
         ;; semantic web goodies and box/arrow graphs
         io.github.jackrusher/mundaneum {:git/sha "d2c934a12388d88ddb3e53fef92ec2eef97d6140"}
@@ -44,7 +44,7 @@
                                                    "notebooks/images.clj"
                                                    "notebooks/logo.clj"
                                                    "notebooks/semantic.clj"
-                                                   "notebooks/sicmutils.clj"
+                                                   "notebooks/emmy.clj"
                                                    "notebooks/rule_30.clj"
                                                    "notebooks/zipper_with_scars.clj"]}
                                :main-opts ["-m" "babashka.cli.exec"]}

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -17,7 +17,7 @@
   ;; or call `clerk/show!` explicitly
   (clerk/show! "notebooks/introduction.clj")
   (clerk/show! "notebooks/data_science.clj")
-  (clerk/show! "notebooks/sicmutils.clj")
+  (clerk/show! "notebooks/emmy.clj")
   (clerk/show! "notebooks/rule_30.clj")
   (clerk/show! "notebooks/semantic.clj")
   (clerk/show! "notebooks/images.clj")

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@
         :description "Some examples about dealing with images."}
        {:title "The double pendulum"
         :preview "https://cdn.nextjournal.com/data/Qmdhk9WEogAvH9cgehnpq3REkATa91JiWgYNUtoSW74Q9A?filename=CleanShot%202021-11-30%20at%2018.45.46@2x.png&content-type=image/png"
-        :path "notebooks/sicmutils.clj"
+        :path "notebooks/emmy.clj"
         :description "Simulate and visualize physical systems from the REPL."}
        {:title "Rule 30"
         :preview "https://cdn.nextjournal.com/data/QmQCrqkdYtKfNm9CGbXhzY4cy6qG8xhpWaCRPF5m6biLgV?filename=CleanShot%202021-11-30%20at%2018.46.55@2x.png&content-type=image/png"

--- a/notebooks/emmy_repro.clj
+++ b/notebooks/emmy_repro.clj
@@ -1,0 +1,17 @@
+(ns emmy-repro
+  (:require [emmy.env :as e]
+            [emmy.mechanics.lagrange]))
+
+;; ## BUG 1:
+
+;; This notebook takes close to 2 seconds to evaluate:
+
+;; Clerk evaluated '/Users/sritchie/code/clj/clerk-demo/notebooks/emmy_repro.clj' in 1853.674042ms.
+
+(defn angles->rect [theta1]
+  (e/sin theta1))
+
+
+;; Form the final Langrangian in generalized coordinates (the angles of each
+;; segment) by composing `L-rect` with a properly transformed `angles->rect`
+;; coordinate transform!

--- a/notebooks/index.md
+++ b/notebooks/index.md
@@ -3,6 +3,6 @@
 ## 🥁 [Intro](#/notebooks/introduction.clj)
 ## 📈 [Data Science](#/notebooks/data_science.clj)
 ## 🕸 [Semantic Queries](#/notebooks/semantic.clj)
-## 🔬 [SICMUtils Double Pendulum](#/notebooks/sicmutils.clj)
+## 🔬 [Emmy Double Pendulum](#/notebooks/emmy.clj)
 ## 🕹 [Rule 30](#/notebooks/rule_30.clj)
 ## ✏️ [Markdown Files](#/notebooks/markdown.md)


### PR DESCRIPTION
This PR:

- Migrates the `sicmutils` notebook over to Emmy. This uses our new function compilation (still clunky), which brings the notebook evaluation down under 1s.
- Adds an `emmy-repro` namespace with the two big current bugs that will cause trouble for the conj presentation. The main one is that including any code at all that uses a function from `sicmutils.env` causes the clerk evaluation time to spike.

```clj
(ns emmy-repro
  (:require [emmy.env :as e]
            [emmy.mechanics.lagrange]))

;; ## BUG 1:

;; This notebook takes close to 2 seconds to evaluate:

;; Clerk evaluated '/Users/sritchie/code/clj/clerk-demo/notebooks/emmy_repro.clj' in 1853.674042ms.

;; Form the final Langrangian in generalized coordinates (the angles of each
;; segment) by composing `L-rect` with a properly transformed `angles->rect`
;; coordinate transform!

;; ## BUG 2:
;;
;; The following form:

#_
(let [L (emmy.mechanics.lagrange/L-pendulum 'g 'm 'l)]
  (((e/Lagrange-equations L)
    (e/literal-function 'theta_1))
   't))

;; Evaluates to this:
(e/literal-number
 '(- (* 1/2 m 2 l (((expt D 2) theta_1) t) l) (* g m l (- (sin (theta_1 t))))))


;; But if I include it in a notebook, I get this:

;; Execution error (NullPointerException) at clojure.tools.analyzer.jvm.utils/members* (utils.clj:272).
;; Cannot invoke "java.lang.Class.getName()" because the return value of "clojure.lang.IFn.invoke(Object)" is null
```