### PR TITLE
Fix URL for The_Sower.jpg in images.clj

### DIFF
--- a/notebooks/images.clj
+++ b/notebooks/images.clj
@@ -23,7 +23,7 @@
 ;; Commons requires a User-Agent header to be set when requesting the image, we
 ;; use babashka.http-client.
 (ImageIO/read
- (-> (http/get "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/The_Sower.jpg/1510px-The_Sower.jpg"
+ (-> (http/get "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/The_Sower.jpg/1280px-The_Sower.jpg"
                {:as :stream})
      :body))
 


### PR DESCRIPTION
The current URL for The_Sower.jpg is invalid. This PR fixes the URL.